### PR TITLE
Throw error on no servername

### DIFF
--- a/pm-pal-parser.ps1
+++ b/pm-pal-parser.ps1
@@ -572,6 +572,8 @@ if ((Test-Path -Path $WithoutPMFolder) -and (Test-Path -Path $WithPMFolder)) {
             if ($p) { $WithoutPMProcessorTime += $p }
             $l = Measure-ProcessorQueueLength | Add-Member -MemberType NoteProperty -Name 'Server' -Value $servername -PassThru
             if ($l) { $WithoutPMProcessorQueueLength += $l }
+        } else {
+            throw("Unable to retrieve the server name from $f")
         }
     }
     $WithPMWorkingProcess = @()


### PR DESCRIPTION
Not having a server name shows that the output is not in the format expected.  This will throw an error and stop additional processing when no servername is found.